### PR TITLE
Split out net.twisterrob.travel (BLT) from SVN monorepo

### DIFF
--- a/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.inventory.rules
+++ b/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.inventory.rules
@@ -30,6 +30,7 @@ match /Libraries/twister-lib-android/
 	# It was first used in Inventory in r1127, when it was initially imported.
 	# Before that, it was only used in Better London Travel.
 	min revision 686
+	max revision 3342
 	repository net.twisterrob.inventory.git
 	branch master
 	# svn:externals
@@ -41,6 +42,7 @@ match /Libraries/twister-lib-java/
 	# It was first used in Inventory in r1127, when it was initially imported.
 	# Before that, it was only used in Better London Travel.
 	min revision 685
+	max revision 3342
 	repository net.twisterrob.inventory.git
 	branch master
 	# svn:externals

--- a/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.libraries.rules
+++ b/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.libraries.rules
@@ -6,6 +6,11 @@ match /Libraries/twister-lib-android/
 	# It was first used in Better London Travel in r690.
 	# It was first used in Inventory in r1127, when it was initially imported.
 	min revision 686
+	# r3342 was the last change
+	# r3343 removed external reference from Inventory
+	# r3377 removed external reference from Better London Travel
+	# r3378	moved as part of https://github.com/TWiStErRob/net.twisterrob.inventory/issues/171
+	max revision 3342
 	repository net.twisterrob.libraries.git
 	branch master
 	# svn:externals
@@ -17,10 +22,23 @@ match /Libraries/twister-lib-java/
 	# It was first used in Better London Travel in r691.
 	# It was first used in Inventory in r1127, when it was initially imported.
 	min revision 685
+	# r3342 was the last change
+	# r3343 removed external reference from Inventory
+	# r3377 removed external reference from Better London Travel
+	# r3378	moved as part of https://github.com/TWiStErRob/net.twisterrob.inventory/issues/171
+	max revision 3342
 	repository net.twisterrob.libraries.git
 	branch master
 	# svn:externals
 	prefix /twister-lib-java/
+end match
+
+match /Libraries/twister-lib-android/maven/
+	# Noticed it too late, the project already evolved, but historically there was an external in this repo.
+	# r688 added the external reference: https://github.com/mosabua/maven-android-sdk-deployer/trunk
+	# At the time, it likely referenced this commit:
+	# https://github.com/simpligility/maven-android-sdk-deployer/tree/ac28677a4d35e8482c2ab5688288bf7ad2e57f23
+	action ignore
 end match
 
 

--- a/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.travel.rules
+++ b/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.travel.rules
@@ -37,6 +37,7 @@ match /Libraries/twister-lib-android/
 	# r686 is the initial import of twister-lib-android.
 	# It was first used in BLT in r690.
 	min revision 686
+	max revision 3342
 	repository net.twisterrob.travel.git
 	branch master
 	# svn:externals
@@ -47,6 +48,7 @@ match /Libraries/twister-lib-java/
 	# r685 is the initial import of twister-lib-java.
 	# It was first used in BLT in r691.
 	min revision 685
+	max revision 3342
 	repository net.twisterrob.travel.git
 	branch master
 	# svn:externals

--- a/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.travel.rules
+++ b/scripts/special/svn2git-migration/conf/monorepo-split-net.twisterrob.travel.rules
@@ -8,9 +8,29 @@ match /Projects/Better London Travel/
 	# but immediately renamed to /Projects/Better London Travel/ in 547.
 	# r2025 is the first public release on Google Play Store.
 	min revision 548
+	# r3341 was the last change
+	# r3377 moved in https://github.com/TWiStErRob/net.twisterrob.travel/issues/2
+    max revision 3341
 	repository net.twisterrob.travel.git
 	branch master
 	prefix /
+end match
+
+match /Projects/Better London Travel/(PullToRefresh|libs/ActionBar-PullToRefresh-0.8-library|libs/ActionBar-PullToRefresh-0.8-appcompat)/
+	# r718 added the library as external:
+	# https://github.com/chrisbanes/ActionBar-PullToRefresh/tags/v0.8 PullToRefresh
+	# r789 moved the external to /libs:
+	# https://github.com/chrisbanes/ActionBar-PullToRefresh/tags/v0.8/library ActionBar-PullToRefresh-0.8-library
+    # https://github.com/chrisbanes/ActionBar-PullToRefresh/tags/v0.8/extras/actionbarcompat ActionBar-PullToRefresh-0.8-appcompat
+	# r1948 removed the PullToRefresh related externals from /libs.
+	# r2025 is the first (and only at the moment) release of Better London Travel.
+	# So, instead of tracking these binary files, it's going to be ignored.
+	action ignore
+	#min revision 718
+	#max revision 789
+	#repository net.twisterrob.travel.git
+	#branch master
+	#prefix /PullToRefresh/
 end match
 
 match /Libraries/twister-lib-android/
@@ -47,6 +67,13 @@ match /Libraries/android_google-play-services_lib/
 	#repository net.twisterrob.travel.git
 	#branch master
 	#prefix /libs/android_google-play-services_lib/
+end match
+
+match /Libraries/android_google-play-services_lib_froyo/
+	# r788 imported the library first along with android_google-play-services_lib.
+	# Couldn't find any svn:externals reference to this folder.
+	action ignore
+	#min revision 788
 end match
 
 match /Libraries/android_support-v7_appcompat/


### PR DESCRIPTION
* Contributes to https://github.com/TWiStErRob/net.twisterrob.travel/issues/2