### PR TITLE
Fix Kotlin 2.4 main.kts compilation problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,12 @@ env:
   # -progressive: use latest features
   # TODEL -Xuse-fir-lt when K2 is fully implemented for scripts.
   # > warning: scripts are not yet supported with K2 in LightTree mode, consider using K1 or disable LightTree mode with -Xuse-fir-lt=false
-  # TODEL -Xannotation-default-target when the default changes.
-  # > warning: this annotation is currently applied to the value parameter only, but in the future it will also be applied to field.
-  # > - To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.
-  # > - To keep applying to the value parameter only, use the '@param:' annotation target.
   KOTLINC: >
     kotlinc
     -Xallow-any-scripts-in-source-roots
     -Werror
     -progressive
     -Xuse-fir-lt=false
-    -Xannotation-default-target=param-property
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # -Xallow-any-scripts-in-source-roots: https://youtrack.jetbrains.com/issue/KT-62575
-  # -Werror: be strict
-  # -progressive: use latest features
-  # TODEL -Xuse-fir-lt when K2 is fully implemented for scripts.
-  # > warning: scripts are not yet supported with K2 in LightTree mode, consider using K1 or disable LightTree mode with -Xuse-fir-lt=false
+  # compile-kotlin-script.main.kts: workaround for https://youtrack.jetbrains.com/issue/KT-87047 in Kotlin 2.4.x
+  # --add-opens: allow the verifier to extend Kotlin's scripting classloader.
+  # -progressive: use latest features.
+  # -Werror: be strict; not explicitly present, but implied by how the compiler script treats warnings.
   KOTLINC: >
-    kotlinc
-    -Xallow-any-scripts-in-source-roots
-    -Werror
+    kotlin
+    -J--add-opens=java.base/java.net=ALL-UNNAMED
+    ${{ github.workspace }}/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
     -progressive
-    -Xuse-fir-lt=false
 
 jobs:
 

--- a/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
+++ b/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
@@ -102,6 +102,7 @@ fun reportCompilationResult(result: ResultWithDiagnostics<CompiledScript>): Bool
 }
 
 require(args.isNotEmpty()) {
+	@Suppress("detekt.MaxLineLength")
 	error("Usage: kotlin -J--add-opens=java.base/java.net=ALL-UNNAMED compile-kotlin-script.main.kts [compiler options] <script.main.kts>")
 }
 val script = File(args.last())

--- a/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
+++ b/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
@@ -1,0 +1,113 @@
+import org.jetbrains.kotlin.mainKts.MainKtsScript
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+import kotlin.script.experimental.api.CompiledScript
+import kotlin.script.experimental.api.ResultWithDiagnostics
+import kotlin.script.experimental.api.ScriptDiagnostic
+import kotlin.script.experimental.api.compilerOptions
+import kotlin.script.experimental.api.valueOrThrow
+import kotlin.script.experimental.dependencies.CompoundDependenciesResolver
+import kotlin.script.experimental.dependencies.FileSystemDependenciesResolver
+import kotlin.script.experimental.dependencies.maven.MavenDependenciesResolver
+import kotlin.script.experimental.dependencies.resolveFromAnnotations
+import kotlin.script.experimental.host.toScriptSource
+import kotlin.script.experimental.jvm.withUpdatedClasspath
+import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
+import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
+
+fun compilerJars(): List<File> {
+	val kotlinMainKtsJarLocation: URL = MainKtsScript::class.java.protectionDomain.codeSource.location
+	val kotlinHomeLibs: File = kotlinMainKtsJarLocation
+		.toURI()
+		.let(::File)
+		.also { require(it.isFile) { "MainKtsScript was not loaded from a JAR: $kotlinMainKtsJarLocation" } }
+		.parentFile
+
+	return listOf(
+		// Contains ScriptJvmK2CompilerIsolated, which kotlin-main-kts.jar references but does not contain.
+		"kotlin-scripting-compiler.jar",
+		// Contains the compiler implementation used by ScriptJvmK2CompilerIsolated, such as MessageCollector.
+		"kotlin-compiler.jar",
+		// Contains scripting compiler configuration classes, such as ScriptingConfigurationKeys.
+		"kotlin-scripting-compiler-impl.jar",
+	)
+		.map(kotlinHomeLibs::resolve)
+		.onEach { require(it.isFile()) { "Kotlin distribution is missing: $it" } }
+}
+
+/** Extend the kotlin-main-kts.jar loader without duplicating scripting API classes. */
+fun extendScriptingCompilerClassLoader(compilerJars: List<File>) {
+	val hostClassLoader: URLClassLoader = BasicJvmScriptingHost::class.java.classLoader as? URLClassLoader
+		?: error("Expected BasicJvmScriptingHost to be loaded by a URLClassLoader")
+	val addUrl = URLClassLoader::class.java
+		.getDeclaredMethod("addURL", URL::class.java)
+		.apply { isAccessible = true }
+	compilerJars.forEach { addUrl.invoke(hostClassLoader, it.toURI().toURL()) }
+}
+
+/**
+ * Parses string-literal coordinates from annotations in these forms:
+ * ```kotlin
+ * @file:Repository("https://repo1.maven.org/maven2/")
+ * @file:DependsOn("group:first:1.0")
+ * @file:DependsOn(
+ *     "group:second:1.0",
+ *     "group:third:1.0",
+ * )
+ * ```
+ * [Repository.options] and [DependsOn.options] is not supported.
+ */
+fun parseDependencyAnnotations(script: File): List<Annotation> {
+	fun String.annotationArguments(name: String): Sequence<String> =
+		Regex("""@file:${Regex.escape(name)}\(([^)]*)\)""")
+			.findAll(this)
+			.flatMap { it.groupValues[1].splitToSequence(',') }
+			.map { it.trim().removeSurrounding("\"") }
+			.filter { it.isNotEmpty() }
+
+	val scriptText = script.readText()
+	return buildList {
+		scriptText.annotationArguments("Repository").forEach { add(Repository(it)) }
+		scriptText.annotationArguments("DependsOn").forEach { add(DependsOn(it)) }
+	}
+}
+
+fun compileScript(script: File, compilerArguments: List<String>): ResultWithDiagnostics<CompiledScript> {
+	val host = BasicJvmScriptingHost()
+	return host.runInCoroutineContext {
+		val dependencyClasspath = CompoundDependenciesResolver(
+			FileSystemDependenciesResolver(),
+			MavenDependenciesResolver(),
+		)
+			.resolveFromAnnotations(parseDependencyAnnotations(script))
+			.valueOrThrow()
+		host.compiler(
+			script = script.toScriptSource(),
+			scriptCompilationConfiguration = createJvmCompilationConfigurationFromTemplate<MainKtsScript> {
+				compilerOptions.append(compilerArguments)
+			}
+				.withUpdatedClasspath(dependencyClasspath),
+		)
+	}
+}
+
+fun reportCompilationResult(result: ResultWithDiagnostics<CompiledScript>): Boolean {
+	result.reports.forEach { report ->
+		val location = report.location?.let { "${it.start.line}:${it.start.col}: " }
+		System.err.println("${report.severity}: ${location.orEmpty()}${report.message}")
+	}
+	return result is ResultWithDiagnostics.Failure
+			|| result.reports.any { it.severity == ScriptDiagnostic.Severity.WARNING }
+}
+
+require(args.isNotEmpty()) {
+	error("Usage: kotlin -J--add-opens=java.base/java.net=ALL-UNNAMED compile-kotlin-script.main.kts [compiler options] <script.main.kts>")
+}
+val script = File(args.last())
+	.also { require(it.isFile()) { "$it does not exist" } }
+val compilerArguments = args.dropLast(1)
+extendScriptingCompilerClassLoader(compilerJars())
+if (reportCompilationResult(compileScript(script, compilerArguments))) {
+	error("Script compilation failed: ${script.absolutePath}")
+}

--- a/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
+++ b/scripts/special/compile-kotlin-script/compile-kotlin-script.main.kts
@@ -15,6 +15,7 @@ import kotlin.script.experimental.host.toScriptSource
 import kotlin.script.experimental.jvm.withUpdatedClasspath
 import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
+import kotlin.system.exitProcess
 
 fun compilerJars(): List<File> {
 	val kotlinMainKtsJarLocation: URL = MainKtsScript::class.java.protectionDomain.codeSource.location
@@ -93,12 +94,14 @@ fun compileScript(script: File, compilerArguments: List<String>): ResultWithDiag
 }
 
 fun reportCompilationResult(result: ResultWithDiagnostics<CompiledScript>): Boolean {
-	result.reports.forEach { report ->
-		val location = report.location?.let { "${it.start.line}:${it.start.col}: " }
-		System.err.println("${report.severity}: ${location.orEmpty()}${report.message}")
-	}
+	result.reports
+		.filter { it.severity >= ScriptDiagnostic.Severity.INFO }
+		.forEach { report ->
+			val location = report.location?.let { "${it.start.line}:${it.start.col}: " }
+			System.err.println("${report.severity}: ${location.orEmpty()}${report.message}")
+		}
 	return result is ResultWithDiagnostics.Failure
-			|| result.reports.any { it.severity == ScriptDiagnostic.Severity.WARNING }
+			|| result.reports.any { it.severity >= ScriptDiagnostic.Severity.WARNING }
 }
 
 require(args.isNotEmpty()) {
@@ -110,5 +113,6 @@ val script = File(args.last())
 val compilerArguments = args.dropLast(1)
 extendScriptingCompilerClassLoader(compilerJars())
 if (reportCompilationResult(compileScript(script, compilerArguments))) {
-	error("Script compilation failed: ${script.absolutePath}")
+	System.err.println("Script compilation failed: ${script.absolutePath}")
+	exitProcess(1)
 }


### PR DESCRIPTION
Fix 1:

<img width="1252" height="663" alt="image" src="https://github.com/user-attachments/assets/f0ba63da-6cb2-4eb7-8a6a-97648965d517" />

Fix 2:

<details><summary>Stacktrace</summary>

```
exception: java.lang.ClassNotFoundException: kotlin.script.experimental.dependencies.Repository
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	at org.jetbrains.kotlin.scripting.resolve.RefineCompilationConfigurationKt.construct(refineCompilationConfiguration.kt:333)
	at org.jetbrains.kotlin.scripting.resolve.RefineCompilationConfigurationKt.construct(refineCompilationConfiguration.kt:310)
	at org.jetbrains.kotlin.scripting.resolve.RefineCompilationConfigurationKt.getScriptCollectedData(refineCompilationConfiguration.kt:298)
	at org.jetbrains.kotlin.scripting.compiler.plugin.services.FirScriptDefinitionProviderService.getRefinedConfiguration$lambda$1$0$0(FirScriptDefinitionProviderService.kt:93)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.K2RefinementUtilKt.refineAllForK2$lambda$1$0(k2RefinementUtil.kt:31)
	at kotlin.script.experimental.impl.RefineUtilsKt.refineOnAnnotationsWithLazyDataCollection(refineUtils.kt:19)
	at org.jetbrains.kotlin.scripting.compiler.plugin.impl.K2RefinementUtilKt.refineAllForK2(k2RefinementUtil.kt:30)
	at org.jetbrains.kotlin.scripting.compiler.plugin.services.FirScriptDefinitionProviderService.getRefinedConfiguration(FirScriptDefinitionProviderService.kt:88)
	at org.jetbrains.kotlin.scripting.compiler.plugin.services.FirScriptConfigurationExtensionImplKt.getOrLoadConfiguration(FirScriptConfigurationExtensionImpl.kt:265)
	at org.jetbrains.kotlin.scripting.compiler.plugin.services.FirScriptConfiguratorExtensionImpl.configure(FirScriptConfigurationExtensionImpl.kt:88)
	at org.jetbrains.kotlin.fir.builder.AbstractRawFirBuilder.convertScriptOrSnippets$lambda$6(AbstractRawFirBuilder.kt:1409)
	at org.jetbrains.kotlin.fir.builder.PsiRawFirBuilder$Visitor.convertScript(PsiRawFirBuilder.kt:1455)
	at org.jetbrains.kotlin.fir.builder.PsiRawFirBuilder.convertScript(PsiRawFirBuilder.kt:199)
	at org.jetbrains.kotlin.fir.builder.PsiRawFirBuilder.convertScript(PsiRawFirBuilder.kt:58)
	at org.jetbrains.kotlin.fir.builder.AbstractRawFirBuilder.convertScriptOrSnippets(AbstractRawFirBuilder.kt:1405)
	at org.jetbrains.kotlin.fir.builder.PsiRawFirBuilder$Visitor.visitKtFile(PsiRawFirBuilder.kt:1336)
	at org.jetbrains.kotlin.fir.builder.PsiRawFirBuilder$Visitor.visitKtFile(PsiRawFirBuilder.kt:222)
	at org.jetbrains.kotlin.psi.KtFile.accept(KtFile.kt:41)
	at org.jetbrains.kotlin.fir.builder.PsiRawFirBuilder.buildFirFile(PsiRawFirBuilder.kt:80)
	at org.jetbrains.kotlin.fir.pipeline.FirUtilsKt.buildFirFromKtFiles(firUtils.kt:55)
	at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFrontendPipelinePhase.executePhase(JvmFrontendPipelinePhase.kt:166)
	at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFrontendPipelinePhase.executePhase(JvmFrontendPipelinePhase.kt:51)
	at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:63)
	at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:53)
	at org.jetbrains.kotlin.config.phaser.NamedCompilerPhase.invoke(CompilerPhase.kt:102)
	at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:22)
	at org.jetbrains.kotlin.config.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:53)
	at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.runPhasedPipeline(AbstractCliPipeline.kt:135)
	at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.executeAndReturnPipeLineArtifact(AbstractCliPipeline.kt:89)
	at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.executeAndReturnPipeLineArtifact$default(AbstractCliPipeline.kt:49)
	at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.execute(AbstractCliPipeline.kt:40)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:54)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:45)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:94)
	at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:366)
	at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:344)
	at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:306)
	at org.jetbrains.kotlin.cli.common.CLICompiler$Companion.doMainNoExit(CLICompiler.kt:445)
	at org.jetbrains.kotlin.cli.common.CLICompiler$Companion.doMainNoExit$default(CLICompiler.kt:440)
	at org.jetbrains.kotlin.cli.common.CLICompiler$Companion.doMain(CLICompiler.kt:432)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler$Companion.main(K2JVMCompiler.kt:237)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.main(K2JVMCompiler.kt)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.jetbrains.kotlin.preloading.Preloader.run(Preloader.java:87)
	at org.jetbrains.kotlin.preloading.Preloader.main(Preloader.java:44)
```

</details>

[kotlin-main-kts-compile-options.md](https://github.com/user-attachments/files/30150953/kotlin-main-kts-compile-options.md)
